### PR TITLE
chore(KFLUXVNGD-88): Add securityContext to values file

### DIFF
--- a/config/ocp/crossplane-helm-values.yaml
+++ b/config/ocp/crossplane-helm-values.yaml
@@ -5,3 +5,7 @@ securityContextCrossplane:
 securityContextRBACManager:
   runAsUser: null
   runAsGroup: null
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  fsGroup: 1000


### PR DESCRIPTION
Crossplane deployment is failing with error container not set to runAsNonRoot so adding securityContext to values file.

Jira-Url: https://issues.redhat.com/browse/KFLUXVNGD-88