### PR TITLE
Fix function runtime config patch

### DIFF
--- a/config/ocp/kustomization.yaml
+++ b/config/ocp/kustomization.yaml
@@ -13,4 +13,4 @@ patches:
           name: function-runtime-config
     target:
       kind: Function
-      group: pkg.crossplane.io/v1
+      group: pkg.crossplane.io


### PR DESCRIPTION
The Deployments for our Functions are currently failing on OCP because the patch isn't properly matching any targets.