### PR TITLE
Add simple integration test using kind

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,9 @@
 name: CI Workflow
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -47,3 +50,29 @@ jobs:
         run: |
           echo "If this step fails, kube-linter found issues. Check the output of the scan step above."
           [[ "${{ steps.kube-linter-action-scan.outcome }}" == "success" ]]
+
+  deploy-test-cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1
+
+      - name: Deploy
+        shell: bash
+        run: |
+          ./scripts/deploy.sh
+          kubectl apply -k examples/provider-kubernetes-in-cluster
+
+      - name: Test XNamespaces
+        shell: bash
+        run: |
+          ./scripts/test-xnamespaces.sh
+
+      - name: Cleanup
+        shell: bash
+        run: |
+          kubectl delete -k examples/provider-kubernetes-in-cluster
+          ./scripts/cleanup.sh

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ with Konflux.
 The quickest way to install everything is to run the `deploy.sh` script.
 
 ```bash
-./deploy.sh
+./scripts/deploy.sh
 ```
 
 This will install crossplane from a helm chart and then deploy our control plane
@@ -42,7 +42,7 @@ kubectl apply -k config/
 # Cleanup
 
 ```bash
-./cleanup.sh
+./scripts/cleanup.sh
 ```
 
 # CompositeResourceDefinitions (XRDs)
@@ -75,4 +75,8 @@ kubectl apply -k examples/provider-kubernetes-in-cluster
 
 ### Usage
 
-See the [examples](./examples/xnamespace/).
+See the [examples](./examples/xnamespace/) or execute this script:
+
+```bash
+./scripts/test-xnamespaces.sh
+```

--- a/cleanup.sh
+++ b/cleanup.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -eu -o pipefail
-
-kubectl delete --ignore-not-found -k config/
-
-kustomize build --enable-helm crossplane/ | kubectl delete --ignore-not-found -f -
-
-kubectl get crds -o name | grep "\.crossplane\.io$" | xargs --no-run-if-empty kubectl delete

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -eu -o pipefail
-
-kustomize build --enable-helm crossplane/ | kubectl apply -f -
-
-kubectl wait --for=condition=Available deployment -n crossplane-system --all --timeout=30s
-
-kubectl apply -k config/

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
+
+kubectl delete --ignore-not-found -k $ROOT/config/
+
+kustomize build --enable-helm $ROOT/crossplane/ | kubectl delete --ignore-not-found -f -
+
+kubectl get crds -o name | grep "\.crossplane\.io$" | xargs --no-run-if-empty kubectl delete

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
+
+kustomize build --enable-helm $ROOT/crossplane/ | kubectl apply -f -
+kubectl wait --for=condition=Available deployment -n crossplane-system --all --timeout=30s
+
+kubectl apply -k $ROOT/config/
+kubectl wait --for=condition=Healthy functions,providers --all --timeout=30s

--- a/scripts/test-xnamespaces.sh
+++ b/scripts/test-xnamespaces.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
+
+kubectl apply -f $ROOT/examples/xnamespace
+kubectl wait --for=condition=Ready namespaces.eaas.konflux-ci.dev/my-namespace
+kubectl get secret/my-claim-secret
+kubectl delete -f $ROOT/examples/xnamespace
+kubectl wait --for=delete objects --all --timeout=3m


### PR DESCRIPTION
Scripts are now consolidated under the `scripts` directory. The XNamespace claim test doesn't try to use the provisioned namespace yet because the api server in the kubeconfig is hard coded and will only resolve from within the cluster.