### PR TITLE
Sanitize remote namespace names for XNamespace resources

### DIFF
--- a/config/xnamespace/templates/ns.yaml
+++ b/config/xnamespace/templates/ns.yaml
@@ -1,15 +1,19 @@
 ---
+{{- $ns := .observed.composite.resource.metadata.name | replace "." "-" }}
+
 apiVersion: kubernetes.crossplane.io/v1alpha2
 kind: Object
 metadata:
   annotations:
     gotemplating.fn.crossplane.io/composition-resource-name: namespace
+    crossplane.io/external-name: {{ $ns }}
 spec:
   forProvider:
     manifest:
       apiVersion: v1
       kind: Namespace
       metadata:
+        name: {{ $ns }}
         labels:
           konflux-ci.dev/namespace-type: eaas
   providerConfigRef:
@@ -19,4 +23,4 @@ spec:
 apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
 kind: Context
 data:
-  namespace: {{ .observed.resources.namespace.resource.metadata.name }}
+  namespace: {{ $ns }}

--- a/examples/xnamespace/claim.yaml
+++ b/examples/xnamespace/claim.yaml
@@ -2,7 +2,7 @@
 apiVersion: eaas.konflux-ci.dev/v1alpha1
 kind: Namespace
 metadata:
-  name: my-namespace
+  name: my-namespace-1.0
 spec:
   writeConnectionSecretToRef:
-    name: my-claim-secret
+    name: my-namespace-1.0-secret

--- a/scripts/test-xnamespaces.sh
+++ b/scripts/test-xnamespaces.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
 
 kubectl apply -f $ROOT/examples/xnamespace
-kubectl wait --for=condition=Ready namespaces.eaas.konflux-ci.dev/my-namespace
-kubectl get secret/my-claim-secret
+kubectl wait --for=condition=Ready namespaces.eaas.konflux-ci.dev/my-namespace-1.0
+kubectl get secret/my-namespace-1.0-secret
 kubectl delete -f $ROOT/examples/xnamespace
 kubectl wait --for=delete objects --all --timeout=3m


### PR DESCRIPTION
Dots are allowed in k8s resource names with the exception of namespaces. The namespace will now be named after the composite resource rather than the managed Object resource (making it easier to map XNamespaces to remote namespaces) and replaces dots with hyphens.