### PR TITLE
Fix the permissions needed to upload code scanning sarif reports

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,13 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   build-and-scan:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes the issue seen on the `main` branch. For example: https://github.com/konflux-ci/crossplane-control-plane/actions/runs/13706439875/job/38332746021