### PR TITLE
Add xtestplatformcluster XRD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,11 @@ jobs:
         run: |
           ./scripts/test-xnamespaces.sh
 
+      - name: Test XTestPlatformCluster
+        shell: bash
+        run: |
+          ./scripts/test-xtestplatformcluster.sh
+
       - name: Cleanup
         shell: bash
         run: |

--- a/config/functions.yaml
+++ b/config/functions.yaml
@@ -23,10 +23,16 @@ spec:
                 - mountPath: /templates/xnamespace
                   name: xnamespace-templates
                   readOnly: true
+                - mountPath: /templates/xtestplatformcluster
+                  name: xtestplatformcluster-templates
+                  readOnly: true
           volumes:
             - name: xnamespace-templates
               configMap:
                 name: xnamespace-templates
+            - name: xtestplatformcluster-templates
+              configMap:
+                name: xtestplatformcluster-templates
 
 ---
 apiVersion: pkg.crossplane.io/v1

--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - functions.yaml
   - provider-kubernetes.yaml
   - xnamespace/
+  - xtestplatformcluster/

--- a/config/xtestplatformcluster/composition.yaml
+++ b/config/xtestplatformcluster/composition.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: testplatform-ephemeral-cluster
+spec:
+  writeConnectionSecretsToNamespace: crossplane-connections
+  compositeTypeRef:
+    apiVersion: ci.openshift.org/v1alpha1
+    kind: XTestPlatformCluster
+  mode: Pipeline
+  pipeline:
+  - step: create-ephemeral-cluster
+    functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      kind: GoTemplate
+      source: FileSystem
+      fileSystem:
+        dirPath: /templates/xtestplatformcluster/create-ephemeral-cluster.yaml
+
+  - step: report-conditions
+    functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      kind: GoTemplate
+      source: FileSystem
+      fileSystem:
+        dirPath: /templates/xtestplatformcluster/report-conditions.yaml
+
+  - step: write-connection-details
+    functionRef:
+      name: function-go-templating
+    input:
+      apiVersion: gotemplating.fn.crossplane.io/v1beta1
+      kind: GoTemplate
+      source: FileSystem
+      fileSystem:
+        dirPath: /templates/xtestplatformcluster/write-connection-details.yaml
+
+  - step: auto-detect-ready-composed-resources
+    functionRef:
+      name: function-auto-ready

--- a/config/xtestplatformcluster/kustomization.yaml
+++ b/config/xtestplatformcluster/kustomization.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - xrd.yaml
+  - composition.yaml
+configMapGenerator:
+  - name: xtestplatformcluster-templates
+    namespace: crossplane-system
+    files:
+      - templates/create-ephemeral-cluster.yaml
+      - templates/report-conditions.yaml
+      - templates/write-connection-details.yaml
+generatorOptions:
+  disableNameSuffixHash: true

--- a/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
+++ b/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: kubernetes.crossplane.io/v1alpha2
+kind: Object
+metadata:
+  annotations:
+    gotemplating.fn.crossplane.io/composition-resource-name: ec
+  name: managed-{{ .observed.composite.resource.metadata.name }}
+spec:
+  forProvider:
+    manifest:
+      apiVersion: ci.openshift.io/v1
+      kind: EphemeralCluster
+      metadata:
+        name: {{ .observed.composite.resource.metadata.name }}
+        namespace: ephemeral-cluster
+      spec: {{ .observed.composite.resource.spec|toPrettyJson }}
+  providerConfigRef:
+    name: testplatform-kubernetes-provider-config

--- a/config/xtestplatformcluster/templates/report-conditions.yaml
+++ b/config/xtestplatformcluster/templates/report-conditions.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+kind: ClaimConditions
+{{ if eq .observed.resources.ec.resource.status.atProvider.manifest.status.conditions nil -}}
+conditions: []
+{{ else if eq (len .observed.resources.ec.resource.status.atProvider.manifest.status.conditions) 0 -}}
+conditions: []
+{{ else -}}
+conditions:
+{{ range .observed.resources.ec.resource.status.atProvider.manifest.status.conditions -}}
+- type: {{ default "" .type|quote }}
+  status: {{ default "" .status|quote }}
+  lastTransitionTime: {{ default "" .lastTransitionTime|quote }}
+  reason: {{ default "" .reason|quote }}
+  message: {{ default "" .message|quote }}
+  target: "CompositeAndClaim"
+{{ end -}}
+{{ end -}}

--- a/config/xtestplatformcluster/templates/write-connection-details.yaml
+++ b/config/xtestplatformcluster/templates/write-connection-details.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+kind: CompositeConnectionDetails
+{{ if eq .observed.resources.ec.resource.status.atProvider.manifest.status nil -}}
+data: {}
+{{ else -}}
+data:
+  kubeconfig: {{ default (""|quote) (.observed.resources.ec.resource.status.atProvider.manifest.status.kubeconfig|b64enc) }}
+{{ end -}}

--- a/config/xtestplatformcluster/xrd.yaml
+++ b/config/xtestplatformcluster/xrd.yaml
@@ -1,0 +1,195 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xtestplatformclusters.ci.openshift.org
+spec:
+  group: ci.openshift.org
+  names:
+    kind: XTestPlatformCluster
+    plural: xtestplatformclusters
+  claimNames:
+    kind: TestPlatformCluster
+    plural: testplatformclusters
+  connectionSecretKeys:
+    - kubeconfig
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            properties:
+              ciOperator:
+                description: CIOperatorSpec contains what is needed to run ci-operator
+                properties:
+                  releases:
+                    additionalProperties:
+                      description: |-
+                        UnresolvedRelease describes a semantic release payload
+                        identifier we need to resolve to a pull spec.
+                      properties:
+                        candidate:
+                          description: Candidate describes a candidate release payload
+                          properties:
+                            architecture:
+                              description: |-
+                                Architecture is the architecture for the product.
+                                Defaults to amd64.
+                              type: string
+                            product:
+                              description: Product is the name of the product being
+                                released
+                              type: string
+                            relative:
+                              description: |-
+                                Relative optionally specifies how old of a release
+                                is requested from this stream. For instance, a value
+                                of 1 will resolve to the previous validated release
+                                for this stream.
+                              type: integer
+                            stream:
+                              description: ReleaseStream is the stream from which
+                                we pick the latest candidate
+                              type: string
+                            version:
+                              description: Version is the minor version to search
+                                for
+                              type: string
+                          required:
+                          - product
+                          - stream
+                          - version
+                          type: object
+                        integration:
+                          description: Integration describes an integration stream
+                            which we can create a payload out of
+                          properties:
+                            include_built_images:
+                              description: |-
+                                IncludeBuiltImages determines if the release we assemble will include
+                                images built during the test itself.
+                              type: boolean
+                            name:
+                              description: Name is the name of the ImageStream
+                              type: string
+                            namespace:
+                              description: Namespace is the namespace in which the
+                                integration stream lives.
+                              type: string
+                          required:
+                          - name
+                          - namespace
+                          type: object
+                        prerelease:
+                          description: Prerelease describes a yet-to-be released payload
+                          properties:
+                            architecture:
+                              description: |-
+                                Architecture is the architecture for the product.
+                                Defaults to amd64.
+                              type: string
+                            product:
+                              description: Product is the name of the product being
+                                released
+                              type: string
+                            relative:
+                              description: |-
+                                Relative optionally specifies how old of a release
+                                is requested from this stream. For instance, a value
+                                of 1 will resolve to the previous validated release
+                                for this stream.
+                              type: integer
+                            version_bounds:
+                              description: VersionBounds describe the allowable version
+                                bounds to search in
+                              properties:
+                                lower:
+                                  type: string
+                                stream:
+                                  description: |-
+                                    Stream dictates which stream to search for a version within the specified bounds
+                                    defaults to 4-stable.
+                                  type: string
+                                upper:
+                                  type: string
+                              required:
+                              - lower
+                              - upper
+                              type: object
+                          required:
+                          - product
+                          - version_bounds
+                          type: object
+                        release:
+                          description: Release describes a released payload
+                          properties:
+                            architecture:
+                              description: |-
+                                Architecture is the architecture for the release.
+                                Defaults to amd64.
+                              type: string
+                            channel:
+                              description: Channel is the release channel to search
+                                in
+                              type: string
+                            version:
+                              description: Version is the minor version to search
+                                for
+                              type: string
+                          required:
+                          - channel
+                          - version
+                          type: object
+                      type: object
+                    type: object
+                  resources:
+                    additionalProperties:
+                      description: |-
+                        ResourceRequirements are resource requests and limits applied
+                        to the individual steps in the job. They are passed directly to
+                        builds or pods.
+                      properties:
+                        limits:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Limits are resource limits applied to an individual step in the job.
+                            These are directly used in creating the Pods that execute the Job.
+                          type: object
+                        requests:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            Requests are resource requests applied to an individual step in the job.
+                            These are directly used in creating the Pods that execute the Job.
+                          type: object
+                      type: object
+                    description: |-
+                      ResourceConfiguration defines resource overrides for jobs run
+                      by the operator.
+                    type: object
+                  test:
+                    description: TestSpec determines the workflow will be executed
+                      by the ci-operator to provision a cluster.
+                    properties:
+                      clusterProfile:
+                        type: string
+                      env:
+                        additionalProperties:
+                          type: string
+                        type: object
+                      workflow:
+                        type: string
+                    type: object
+                type: object
+              tearDownCluster:
+                description: |-
+                  When set to true, signals the controller that the ephemeral cluster is no longer needed,
+                  allowing decommissioning procedures to begin.
+                type: boolean
+            required:
+            - ciOperator
+            type: object

--- a/examples/provider-kubernetes-in-cluster/provider-config.yaml
+++ b/examples/provider-kubernetes-in-cluster/provider-config.yaml
@@ -16,6 +16,17 @@ spec:
       key: kubeconfig
 
 ---
+apiVersion: kubernetes.crossplane.io/v1alpha1
+kind: ProviderConfig
+metadata:
+  name: testplatform-kubernetes-provider-config
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  credentials:
+    source: InjectedIdentity
+
+---
 apiVersion: v1
 kind: Secret
 metadata:

--- a/examples/provider-kubernetes-in-cluster/rbac.yaml
+++ b/examples/provider-kubernetes-in-cluster/rbac.yaml
@@ -18,6 +18,12 @@ rules:
   - rolebindings
   verbs:
   - "*"
+- apiGroups:
+  - ci.openshift.io
+  resources:
+  - ephemeralclusters
+  verbs:
+  - "*"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/examples/xtestplatformcluster/claim.yaml
+++ b/examples/xtestplatformcluster/claim.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: ci.openshift.org/v1alpha1
+kind: TestPlatformCluster
+metadata:
+  name: tp-aws-cluster
+spec:
+  ciOperator:
+    releases:
+      initial:
+        integration:
+          name: "4.20"
+          namespace: ocp
+      latest:
+        integration:
+          name: "4.20"
+          namespace: ocp
+    test:
+      clusterProfile: aws
+      env:
+        foo: bar
+      workflow: ipi-aws
+  writeConnectionSecretToRef:
+    name: aws-cluster-kubeconfig

--- a/examples/xtestplatformcluster/namespaces.yaml
+++ b/examples/xtestplatformcluster/namespaces.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ephemeral-cluster

--- a/scripts/test-xnamespaces.sh
+++ b/scripts/test-xnamespaces.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
 
 kubectl apply -f $ROOT/examples/xnamespace
-kubectl wait --for=condition=Ready namespaces.eaas.konflux-ci.dev/my-namespace-1.0
+kubectl wait --for=condition=Ready namespaces.eaas.konflux-ci.dev/my-namespace-1.0 --timeout=3m
 kubectl get secret/my-namespace-1.0-secret
 kubectl delete -f $ROOT/examples/xnamespace
 kubectl wait --for=delete objects --all --timeout=3m

--- a/scripts/test-xtestplatformcluster.sh
+++ b/scripts/test-xtestplatformcluster.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -eu -o pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
+claim_name='tp-aws-cluster'
+
+# Install the EphemeralCluster CRD
+ephemeralcluster_crd='https://raw.githubusercontent.com/openshift/ci-tools/refs/heads/main/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml'
+curl -sSL "$ephemeralcluster_crd" | kubectl apply -f -
+kubectl wait crd/ephemeralclusters.ci.openshift.io --for=condition=Established=true --for=condition=NamesAccepted=true
+
+kubectl apply -f $ROOT/examples/xtestplatformcluster/namespaces.yaml
+
+# Create a claim
+kubectl apply -f $ROOT/examples/xtestplatformcluster/claim.yaml
+kubectl wait xtestplatformclusters.ci.openshift.org -l "crossplane.io/claim-name=$claim_name" --for=condition=Ready=true --for=condition=Synced=true
+
+# Notify that the ephemeral cluster is ready and set the kubeconfig
+ec_patch='[{
+    "op": "add",
+    "path": "/status",
+    "value": {
+        "kubeconfig": "kubeconfig",
+        "conditions": [{
+            "type": "ClusterReady",
+            "status": "True",
+            "lastTransitionTime": "2025-05-28T12:12:12Z",
+            "reason": "",
+            "message": ""
+        }],
+        "phase": "Ready"
+    }
+}]'
+
+kubectl wait objects.kubernetes.crossplane.io -l "crossplane.io/claim-name=$claim_name" --for=condition=Ready=true --for=condition=Synced=true --timeout=3m
+ephemeralcluster="$(kubectl get objects.kubernetes.crossplane.io -l "crossplane.io/claim-name=$claim_name" -o jsonpath='{.items[0].spec.forProvider.manifest.metadata.name}')"
+kubectl -n ephemeral-cluster patch ephemeralclusters.ci.openshift.io/"$ephemeralcluster" --type=json -p="$ec_patch"
+
+# Wait for the EphemeralCluster's conditions to be propagated to both the Composite Resource and Claim
+kubectl wait xtestplatformclusters.ci.openshift.org -l "crossplane.io/claim-name=$claim_name" --for=condition=ClusterReady=true --timeout=3m
+kubectl wait testplatformclusters.ci.openshift.org/"$claim_name" --for=condition=ClusterReady=true --timeout=3m
+
+# Wait for the kubeconfig to be bound to the claim's secret
+kubeconfig_secret="$(kubectl get testplatformclusters.ci.openshift.org/"$claim_name" -o jsonpath='{.spec.writeConnectionSecretToRef.name}')"
+kubectl wait secret/"$kubeconfig_secret" --for=jsonpath='.data.kubeconfig' --timeout=3m
+
+# Make sure the kubeconfig secret holds the right value
+got_kubeconfig="$(kubectl get secret/"$kubeconfig_secret" -o jsonpath='{.data.kubeconfig}')"
+want_kubeconfig='a3ViZWNvbmZpZw=='
+
+if [ "$want_kubeconfig" != "$got_kubeconfig" ]; then
+    echo "want kubeconfig '$want_kubeconfig' but got '$got_kubeconfig'"
+    exit 1
+fi
+
+# Clean everything up
+kubectl delete -f $ROOT/examples/xtestplatformcluster
+kubectl wait objects.kubernetes.crossplane.io --for=delete --all --timeout=3m


### PR DESCRIPTION
Introduce the `xtestplatformcluster` XRD to allows Konflux users to provision ephemeral clusters within the Openshift CI infrastructure.
The directory structure and YAML organization follow the same pattern of the `xnamespace` XRD in order to maintain consistency.

The work gets carried on by the `Composition`, that performs the following steps:
- Create an `EphemeralCluster` CR in the Openshift CI `appci` cluster. Once created, the `ephemeral-cluster-controller` takes over (see https://github.com/openshift/release/pull/65342) and begins provisioning a new ephemeral cluster based on the specification.
- Propagate all conditions from the `EphemeralCluster`'s `.status.conditions` stanza to the Composite Resource and Claim
- When the ephemeral cluster is ready, the `ephemeral-cluster-controller` sets the ephemeral cluster's kubeconfig in the `EphemeralCluster`'s `.status.kubeconfig` field. At this point, the Composition writes the kubeconfig into the `ConnectionDetails`, making it available to the Konflux pipeline, via the `Claim`, as a `Secret`.

This PR requires https://github.com/redhat-appstudio/infra-deployments/pull/6446