### PR TITLE
Add argocd sync-options on xtestplatformcluster resources

### DIFF
--- a/config/xtestplatformcluster/composition.yaml
+++ b/config/xtestplatformcluster/composition.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
   name: testplatform-ephemeral-cluster
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   writeConnectionSecretsToNamespace: crossplane-connections
   compositeTypeRef:

--- a/config/xtestplatformcluster/xrd.yaml
+++ b/config/xtestplatformcluster/xrd.yaml
@@ -2,6 +2,8 @@ apiVersion: apiextensions.crossplane.io/v1
 kind: CompositeResourceDefinition
 metadata:
   name: xtestplatformclusters.ci.openshift.org
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
   group: ci.openshift.org
   names:


### PR DESCRIPTION
In the attempt of bumping the crossplane component in https://github.com/redhat-appstudio/infra-deployments/pull/6639 the `e2e` `ci/prow/appstudio-e2e-tests` failed with the following error (test result [here](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/redhat-appstudio_infra-deployments/6639/pull-ci-redhat-appstudio-infra-deployments-main-appstudio-e2e-tests/1932420964461580288)):
```yaml
apiVersion: argoproj.io/v1alpha1
kind: Application
metadata:
  name: crossplane-control-plane-in-cluster-local
status:
  operationState:
    syncResult:
      resources:
        - group: apiextensions.crossplane.io
          kind: Composition
          message: The Kubernetes API could not find apiextensions.crossplane.io/Composition for requested resource crossplane-system/testplatform-ephemeral-cluster. Make sure the "Composition" CRD is installed on the destination cluster.
          name: testplatform-ephemeral-cluster
          namespace: crossplane-system
          status: SyncFailed
          syncPhase: Sync
          version: v1
        - group: apiextensions.crossplane.io
          kind: CompositeResourceDefinition
          message: The Kubernetes API could not find apiextensions.crossplane.io/CompositeResourceDefinition for requested resource crossplane-system/xtestplatformclusters.ci.openshift.org. Make sure the "CompositeResourceDefinition" CRD is installed on the destination cluster.
          name: xtestplatformclusters.ci.openshift.org
          namespace: crossplane-system
          status: SyncFailed
          syncPhase: Sync
          version: v1
```

By introducing `SkipDryRunOnMissingResource` we should be able to work around the problem.