### PR TITLE
TestPlatformCluster: handle nil kubeconfig

### DIFF
--- a/config/xtestplatformcluster/templates/write-connection-details.yaml
+++ b/config/xtestplatformcluster/templates/write-connection-details.yaml
@@ -1,9 +1,10 @@
 ---
+{{ $status := .observed.resources.ec.resource.status.atProvider.manifest.status -}}
 apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
 kind: CompositeConnectionDetails
-{{ if eq .observed.resources.ec.resource.status.atProvider.manifest.status nil -}}
+{{ if or (eq $status nil) (eq $status.kubeconfig nil) -}}
 data: {}
 {{ else -}}
 data:
-  kubeconfig: {{ default (""|quote) (.observed.resources.ec.resource.status.atProvider.manifest.status.kubeconfig|b64enc) }}
+  kubeconfig: {{ default (""|quote) ($status.kubeconfig|b64enc) }}
 {{ end -}}


### PR DESCRIPTION
This should hopefully solve the following error (coming from the XR):
```
- lastTransitionTime: "2025-07-08T09:35:55Z"
  message: 'cannot compose resources: pipeline step "write-connection-details" returned a fatal result: cannot execute template: template: manifests:8:114: executing "manifests" at <b64enc>: invalid value; expected string'
  reason: ReconcileError
  status: "False"
  type: Synced
```

In some cases, the `.status.kubeconfig` stanza isn't reported at all, which leads to the error mentioned above.