### PR TITLE
TestPlatformCluster: Add PR Event Metadata

### DIFF
--- a/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
+++ b/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
@@ -1,3 +1,4 @@
+{{ $annotations := .observed.composite.resource.metadata.annotations -}}
 ---
 apiVersion: kubernetes.crossplane.io/v1alpha2
 kind: Object
@@ -11,6 +12,11 @@ spec:
       apiVersion: ci.openshift.io/v1
       kind: EphemeralCluster
       metadata:
+        annotations:
+          "ephemeralcluster.ci.openshift.io/pr-event-headers": |
+            {{ get $annotations "ephemeralcluster.ci.openshift.io/pr-event-headers" }}
+          "ephemeralcluster.ci.openshift.io/pr-event-payload": |
+            {{ get $annotations "ephemeralcluster.ci.openshift.io/pr-event-payload" }}
         name: {{ .observed.composite.resource.metadata.name }}
         namespace: ephemeral-cluster
       spec: {{ .observed.composite.resource.spec|toPrettyJson }}

--- a/examples/xtestplatformcluster/claim.yaml
+++ b/examples/xtestplatformcluster/claim.yaml
@@ -2,6 +2,9 @@
 apiVersion: ci.openshift.org/v1alpha1
 kind: TestPlatformCluster
 metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/pr-event-headers: pr-event-headers
+    ephemeralcluster.ci.openshift.io/pr-event-payload: pr-event-payload
   name: tp-aws-cluster
 spec:
   ciOperator:

--- a/scripts/test-xtestplatformcluster.sh
+++ b/scripts/test-xtestplatformcluster.sh
@@ -63,6 +63,24 @@ if [ "$want_passwd" != "$got_passwd" ]; then
     exit 1
 fi
 
+# Make sure the pr event headers holds the expected value
+want_pr_event_headers='pr-event-headers'
+got_pr_event_headers="$(kubectl get testplatformclusters.ci.openshift.org/"$claim_name" -o go-template-file=<(echo '{{ index .metadata.annotations "ephemeralcluster.ci.openshift.io/pr-event-headers" }}'))"
+
+if [ "$want_pr_event_headers" != "$got_pr_event_headers" ]; then
+    echo "want pr event headers '$want_pr_event_headers' but got '$got_pr_event_headers'"
+    exit 1
+fi
+
+# Make sure the pr event payload holds the expected value
+want_pr_event_payload='pr-event-payload'
+got_pr_event_payload="$(kubectl get testplatformclusters.ci.openshift.org/"$claim_name" -o go-template-file=<(echo '{{ index .metadata.annotations "ephemeralcluster.ci.openshift.io/pr-event-payload" }}'))"
+
+if [ "$want_pr_event_payload" != "$got_pr_event_payload" ]; then
+    echo "want pr event payload '$want_pr_event_payload' but got '$got_pr_event_payload'"
+    exit 1
+fi
+
 # Clean everything up
 kubectl delete -f $ROOT/examples/xtestplatformcluster
 kubectl wait objects.kubernetes.crossplane.io --for=delete --all --timeout=3m


### PR DESCRIPTION
Adding the PR event headers and payload into the `EphemeralCluster` object `metadata.annotations` stanza since they are required by the ephemeral cluster controller to properly handle the request.