### PR TITLE
TestPlatformCluster: Report `prowJobURL` and `phase` as Conditions

### DIFF
--- a/config/xtestplatformcluster/templates/report-conditions.yaml
+++ b/config/xtestplatformcluster/templates/report-conditions.yaml
@@ -1,12 +1,20 @@
+{{ $ec_status := .observed.resources.ec.resource.status.atProvider.manifest.status -}}
 ---
 apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
 kind: ClaimConditions
-{{ if eq .observed.resources.ec.resource.status.atProvider.manifest.status.conditions nil -}}
-conditions: []
-{{ else if eq (len .observed.resources.ec.resource.status.atProvider.manifest.status.conditions) 0 -}}
-conditions: []
-{{ else -}}
 conditions:
+- type: _EphemeralClusterPhase
+  status: "True"
+  lastTransitionTime: "1970-01-01T00:00:00Z"
+  reason: ""
+  message: {{ default "" $ec_status.phase|quote }}
+  target: "CompositeAndClaim"
+- type: _ProwJobURL
+  status: "True"
+  lastTransitionTime: "1970-01-01T00:00:00Z"
+  reason: ""
+  message: {{ default "" $ec_status.prowJobURL|quote }}
+  target: "CompositeAndClaim"
 {{ range .observed.resources.ec.resource.status.atProvider.manifest.status.conditions -}}
 - type: {{ default "" .type|quote }}
   status: {{ default "" .status|quote }}
@@ -14,5 +22,4 @@ conditions:
   reason: {{ default "" .reason|quote }}
   message: {{ default "" .message|quote }}
   target: "CompositeAndClaim"
-{{ end -}}
 {{ end -}}

--- a/scripts/test-xtestplatformcluster.sh
+++ b/scripts/test-xtestplatformcluster.sh
@@ -29,6 +29,7 @@ ec_patch='[{
             "reason": "",
             "message": ""
         }],
+        "prowJobURL": "https://prowjob.fake",
         "phase": "Ready"
     }
 }]'
@@ -78,6 +79,24 @@ got_pr_event_payload="$(kubectl get testplatformclusters.ci.openshift.org/"$clai
 
 if [ "$want_pr_event_payload" != "$got_pr_event_payload" ]; then
     echo "want pr event payload '$want_pr_event_payload' but got '$got_pr_event_payload'"
+    exit 1
+fi
+
+# Make sure that `.status.phase` is being reported as a condition
+got_ec_phase="$(kubectl get testplatformclusters.ci.openshift.org/"$claim_name" -o go-template-file=<(echo '{{range .status.conditions}}{{if eq .type "_EphemeralClusterPhase"}}{{.message}}{{end}}{{end}}'))"
+want_ec_phase='Ready'
+
+if [ "$want_ec_phase" != "$got_ec_phase" ]; then
+    echo "want ec phase '$want_ec_phase' but got '$got_ec_phase'"
+    exit 1
+fi
+
+# Make sure that `.status.prowJobURL` is being reported as a condition
+got_pjurl="$(kubectl get testplatformclusters.ci.openshift.org/"$claim_name" -o go-template-file=<(echo '{{range .status.conditions}}{{if eq .type "_ProwJobURL"}}{{.message}}{{end}}{{end}}'))"
+want_pjurl='https://prowjob.fake'
+
+if [ "$want_pjurl" != "$got_pjurl" ]; then
+    echo "want prowJobURL '$want_pjurl' but got '$got_pjurl'"
     exit 1
 fi
 


### PR DESCRIPTION
As per title. Those two information are needed by the [provision-ephemeral-cluster](https://github.com/openshift/konflux-tasks/blob/main/tasks/provision-ephemeral-cluster/0.1/provision-ephemeral-cluster.yaml) task to inform the user about the ProwJob URL and as an exit criteria when the provisioning procedure has failed.

They are not really regular conditions, and in fact they have their own stanza on the `EphemeralCluster`'s status object:
```yaml
status:
  phase: ...
  prowJobURL: ...
```
I chose to put an underscore in front of the condition name (`_EphemeralClusterPhase` and `_ProwJobURL`) to set them apart from the "real" conditions.