### PR TITLE
fix: enable watch on EphemeralCluster Object resource

### DIFF
--- a/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
+++ b/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
@@ -24,5 +24,6 @@ spec:
 {{- if hasKey .observed.composite.resource.spec "tearDownCluster" }}
         tearDownCluster: {{ .observed.composite.resource.spec.tearDownCluster }}
 {{- end }}
+  watch: true
   providerConfigRef:
     name: testplatform-kubernetes-provider-config


### PR DESCRIPTION
The EphemeralCluster Object defaulted to watch: false, causing provider-kubernetes to only poll the external resource status every ~10 minutes. This meant EphemeralCluster status changes (e.g. ClusterReady) were not propagated to the XR/claim within the test's 3-minute timeout, resulting in intermittent CI failures.

Assisted-by: claude-opus-4-6