### PR TITLE
TestPlatformCluster: Remove PR Event Metadata

### DIFF
--- a/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
+++ b/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
@@ -12,11 +12,6 @@ spec:
       apiVersion: ci.openshift.io/v1
       kind: EphemeralCluster
       metadata:
-        annotations:
-          "ephemeralcluster.ci.openshift.io/pr-event-headers": |
-            {{ get $annotations "ephemeralcluster.ci.openshift.io/pr-event-headers" }}
-          "ephemeralcluster.ci.openshift.io/pr-event-payload": |
-            {{ get $annotations "ephemeralcluster.ci.openshift.io/pr-event-payload" }}
         name: {{ .observed.composite.resource.metadata.name }}
         namespace: ephemeral-cluster
       spec:

--- a/examples/xtestplatformcluster/claim.yaml
+++ b/examples/xtestplatformcluster/claim.yaml
@@ -2,9 +2,6 @@
 apiVersion: ci.openshift.org/v1alpha1
 kind: TestPlatformCluster
 metadata:
-  annotations:
-    ephemeralcluster.ci.openshift.io/pr-event-headers: pr-event-headers
-    ephemeralcluster.ci.openshift.io/pr-event-payload: pr-event-payload
   name: tp-aws-cluster
 spec:
   ciOperator:

--- a/scripts/test-xtestplatformcluster.sh
+++ b/scripts/test-xtestplatformcluster.sh
@@ -64,24 +64,6 @@ if [ "$want_passwd" != "$got_passwd" ]; then
     exit 1
 fi
 
-# Make sure the pr event headers holds the expected value
-want_pr_event_headers='pr-event-headers'
-got_pr_event_headers="$(kubectl get testplatformclusters.ci.openshift.org/"$claim_name" -o go-template-file=<(echo '{{ index .metadata.annotations "ephemeralcluster.ci.openshift.io/pr-event-headers" }}'))"
-
-if [ "$want_pr_event_headers" != "$got_pr_event_headers" ]; then
-    echo "want pr event headers '$want_pr_event_headers' but got '$got_pr_event_headers'"
-    exit 1
-fi
-
-# Make sure the pr event payload holds the expected value
-want_pr_event_payload='pr-event-payload'
-got_pr_event_payload="$(kubectl get testplatformclusters.ci.openshift.org/"$claim_name" -o go-template-file=<(echo '{{ index .metadata.annotations "ephemeralcluster.ci.openshift.io/pr-event-payload" }}'))"
-
-if [ "$want_pr_event_payload" != "$got_pr_event_payload" ]; then
-    echo "want pr event payload '$want_pr_event_payload' but got '$got_pr_event_payload'"
-    exit 1
-fi
-
 # Make sure that `.status.phase` is being reported as a condition
 got_ec_phase="$(kubectl get testplatformclusters.ci.openshift.org/"$claim_name" -o go-template-file=<(echo '{{range .status.conditions}}{{if eq .type "_EphemeralClusterPhase"}}{{.message}}{{end}}{{end}}'))"
 want_ec_phase='Ready'


### PR DESCRIPTION
PR even metadata is not available when claiming a cluster from an integration context. Since we should support that scenario as well, we can't rely on those information to be there.