### PR TITLE
Add debug dump on test failure

### DIFF
--- a/scripts/debug-dump.sh
+++ b/scripts/debug-dump.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+#
+# Shared debug dump helper for Crossplane integration tests.
+# Source this file and call register_debug_dump to get a diagnostic
+# dump on test failure.
+#
+# Usage:
+#   source "$(dirname "${BASH_SOURCE[0]}")"/debug-dump.sh
+#   register_debug_dump "testplatformclusters.ci.openshift.org" "tp-aws-cluster"
+#
+
+_DEBUG_DUMP_CLAIM_TYPE=""
+_DEBUG_DUMP_CLAIM_NAME=""
+_DEBUG_DUMP_CLAIM_NAMESPACE=""
+_LOG_TAIL_LINES=100
+
+register_debug_dump() {
+    _DEBUG_DUMP_CLAIM_TYPE="$1"
+    _DEBUG_DUMP_CLAIM_NAME="$2"
+    _DEBUG_DUMP_CLAIM_NAMESPACE="${3:-default}"
+    trap '_dump_debug_info $?' EXIT
+}
+
+_section() {
+    echo ""
+    echo "--- $1 ---"
+    echo ""
+}
+
+_dump_debug_info() {
+    local exit_code=$1
+    if [ "$exit_code" -eq 0 ]; then
+        return
+    fi
+
+    local label="crossplane.io/claim-name=$_DEBUG_DUMP_CLAIM_NAME"
+
+    echo ""
+    echo "================================================================================"
+    echo "DEBUG DUMP (test failed with exit code $exit_code)"
+    echo "================================================================================"
+
+    _dump_claim
+    _dump_composite_resources "$label"
+    _dump_managed_objects "$label"
+    _dump_connection_secrets
+    _dump_events
+    _dump_crossplane_pod_logs
+
+    echo ""
+    echo "================================================================================"
+    echo "END DEBUG DUMP"
+    echo "================================================================================"
+}
+
+_dump_claim() {
+    _section "Claim ($_DEBUG_DUMP_CLAIM_TYPE/$_DEBUG_DUMP_CLAIM_NAME)"
+    kubectl describe "$_DEBUG_DUMP_CLAIM_TYPE"/"$_DEBUG_DUMP_CLAIM_NAME" \
+        -n "$_DEBUG_DUMP_CLAIM_NAMESPACE" 2>/dev/null || echo "  (not found)"
+}
+
+_dump_composite_resources() {
+    local label=$1
+    _section "Composite Resources (XR)"
+    kubectl describe composite -l "$label" 2>/dev/null || echo "  (none found)"
+}
+
+_dump_managed_objects() {
+    local label=$1
+    _section "Managed Objects (provider-kubernetes)"
+    kubectl describe objects.kubernetes.crossplane.io -l "$label" 2>/dev/null || echo "  (none found)"
+}
+
+_dump_connection_secrets() {
+    _section "Connection Secrets"
+
+    local tpl
+    printf -v tpl '{{range .items}} {{.metadata.name}} type={{.type}} keys=[{{range $k, $v := .data}}{{$k}} {{end}}]\n{{end}}'
+
+    echo "Namespace: crossplane-connections"
+    kubectl get secrets -n crossplane-connections -o go-template="$tpl" 2>/dev/null || echo "  (none)"
+    echo ""
+
+    echo "Namespace: $_DEBUG_DUMP_CLAIM_NAMESPACE"
+    kubectl get secrets -n "$_DEBUG_DUMP_CLAIM_NAMESPACE" -o go-template="$tpl" 2>/dev/null || echo "  (none)"
+}
+
+_dump_events() {
+    _section "Events"
+    for ns in "$_DEBUG_DUMP_CLAIM_NAMESPACE" crossplane-system crossplane-connections; do
+        echo "Namespace: $ns"
+        kubectl get events -n "$ns" --sort-by='.lastTimestamp' 2>/dev/null || echo "  (no events or namespace does not exist)"
+        echo ""
+    done
+}
+
+_dump_crossplane_pod_logs() {
+    _section "Provider & Function Pod Logs (last $_LOG_TAIL_LINES lines each)"
+    local pods=$(kubectl get pods -n crossplane-system -o name)
+    for pod in $pods; do
+        echo ">>> $pod"
+        kubectl logs "$pod" -n crossplane-system --tail="$_LOG_TAIL_LINES" --all-containers 2>/dev/null || echo "  (failed to retrieve logs)"
+        echo ""
+    done
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -4,7 +4,7 @@ set -eu -o pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
 
 kustomize build --enable-helm $ROOT/crossplane/ | kubectl apply -f -
-kubectl wait --for=condition=Available deployment -n crossplane-system --all --timeout=30s
+kubectl wait --for=condition=Available deployment -n crossplane-system --all --timeout=120s
 
 kubectl apply -k $ROOT/config/
-kubectl wait --for=condition=Healthy functions,providers --all --timeout=30s
+kubectl wait --for=condition=Healthy functions,providers --all --timeout=120s

--- a/scripts/test-xnamespaces.sh
+++ b/scripts/test-xnamespaces.sh
@@ -2,9 +2,13 @@
 set -eu -o pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
+source "$ROOT/scripts/debug-dump.sh"
+claim_group="namespaces.eaas.konflux-ci.dev"
+claim_name="my-namespace-1.0"
+register_debug_dump "$claim_group" "$claim_name"
 
 kubectl apply -f $ROOT/examples/xnamespace
-kubectl wait --for=condition=Ready namespaces.eaas.konflux-ci.dev/my-namespace-1.0 --timeout=3m
-kubectl get secret/my-namespace-1.0-secret
+kubectl wait --for=condition=Ready "$claim_group"/"$claim_name" --timeout=3m
+kubectl get secret/"$claim_name"-secret
 kubectl delete -f $ROOT/examples/xnamespace
 kubectl wait --for=delete objects --all --timeout=3m

--- a/scripts/test-xtestplatformcluster.sh
+++ b/scripts/test-xtestplatformcluster.sh
@@ -2,7 +2,12 @@
 set -eu -o pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
-claim_name='tp-aws-cluster'
+source "$ROOT/scripts/debug-dump.sh"
+claim_group="testplatformclusters.ci.openshift.org"
+xr_group="xtestplatformclusters.ci.openshift.org"
+claim_name="tp-aws-cluster"
+claim_label="crossplane.io/claim-name=$claim_name"
+register_debug_dump "$claim_group" "$claim_name"
 
 # Install the EphemeralCluster CRD
 ephemeralcluster_crd='https://raw.githubusercontent.com/openshift/ci-tools/refs/heads/main/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml'
@@ -13,7 +18,7 @@ kubectl apply -f $ROOT/examples/xtestplatformcluster/namespaces.yaml
 
 # Create a claim
 kubectl apply -f $ROOT/examples/xtestplatformcluster/claim.yaml
-kubectl wait xtestplatformclusters.ci.openshift.org -l "crossplane.io/claim-name=$claim_name" --for=condition=Synced=true --timeout=3m
+kubectl wait $xr_group -l "$claim_label" --for=condition=Synced=true --timeout=3m
 
 # Simulate what the EphemeralCluster controller does: create a credentials Secret and set secretRef in the EphemeralCluster status.
 test_kubeconfig=$(cat "$ROOT/scripts/testdata/test-kubeconfig.yaml")
@@ -38,15 +43,15 @@ ec_patch='[{
     }
 }]'
 
-ephemeralcluster="$(kubectl get xtestplatformclusters.ci.openshift.org -l "crossplane.io/claim-name=$claim_name" -o jsonpath='{.items[0].metadata.name}')"
+ephemeralcluster="$(kubectl get $xr_group -l "$claim_label" -o jsonpath='{.items[0].metadata.name}')"
 kubectl -n ephemeral-cluster patch ephemeralclusters.ci.openshift.io/"$ephemeralcluster" --type=json -p="$ec_patch"
 
 # Wait for the EphemeralCluster's conditions to be propagated to both the Composite Resource and Claim
-kubectl wait xtestplatformclusters.ci.openshift.org -l "crossplane.io/claim-name=$claim_name" --for=condition=ClusterReady=true --for=condition=Ready=true --timeout=3m
-kubectl wait testplatformclusters.ci.openshift.org/"$claim_name" --for=condition=ClusterReady=true --timeout=3m
+kubectl wait $xr_group -l "$claim_label" --for=condition=ClusterReady=true --for=condition=Ready=true --timeout=3m
+kubectl wait $claim_group/"$claim_name" --for=condition=ClusterReady=true --timeout=3m
 
 # Wait for the cluster credentials to be bound to the claim's secret
-cluster_secret="$(kubectl get testplatformclusters.ci.openshift.org/"$claim_name" -o jsonpath='{.spec.writeConnectionSecretToRef.name}')"
+cluster_secret="$(kubectl get $claim_group/"$claim_name" -o jsonpath='{.spec.writeConnectionSecretToRef.name}')"
 kubectl wait secret/"$cluster_secret" --for=jsonpath='.data.kubeconfig' --timeout=3m
 
 # Make sure the cluster secret holds the right kubeconfig
@@ -68,7 +73,7 @@ if [ "$want_passwd" != "$got_passwd" ]; then
 fi
 
 # Make sure that `.status.phase` is being reported as a condition
-got_ec_phase="$(kubectl get testplatformclusters.ci.openshift.org/"$claim_name" -o go-template-file=<(echo '{{range .status.conditions}}{{if eq .type "_EphemeralClusterPhase"}}{{.message}}{{end}}{{end}}'))"
+got_ec_phase="$(kubectl get $claim_group/"$claim_name" -o go-template-file=<(echo '{{range .status.conditions}}{{if eq .type "_EphemeralClusterPhase"}}{{.message}}{{end}}{{end}}'))"
 want_ec_phase='Ready'
 
 if [ "$want_ec_phase" != "$got_ec_phase" ]; then
@@ -77,7 +82,7 @@ if [ "$want_ec_phase" != "$got_ec_phase" ]; then
 fi
 
 # Make sure that `.status.prowJobURL` is being reported as a condition
-got_pjurl="$(kubectl get testplatformclusters.ci.openshift.org/"$claim_name" -o go-template-file=<(echo '{{range .status.conditions}}{{if eq .type "_ProwJobURL"}}{{.message}}{{end}}{{end}}'))"
+got_pjurl="$(kubectl get $claim_group/"$claim_name" -o go-template-file=<(echo '{{range .status.conditions}}{{if eq .type "_ProwJobURL"}}{{.message}}{{end}}{{end}}'))"
 want_pjurl='https://prowjob.fake'
 
 if [ "$want_pjurl" != "$got_pjurl" ]; then


### PR DESCRIPTION
When an integration test fails (e.g. timeout waiting for a condition), there is no visibility into why. This adds a shared debug-dump helper that automatically prints the state of all critical Crossplane resources on non-zero exit: claims, composite resources, managed objects, connection secrets, events, and provider/function pod logs.

Assisted-by: Claude claude-opus-4-6