### PR TITLE
switch to Konflux OCI Helm chart and pin all images to quay.io digests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,11 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Kustomize
-        uses: multani/action-setup-kustomize@v1
-        with:
-          version: 5.1.1
-
       - name: Run kustomize build
         id: kube-linter-action-scan
         shell: bash

--- a/config/functions.yaml
+++ b/config/functions.yaml
@@ -42,7 +42,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-patch-and-transform:v0.10.4
+  package: quay.io/konflux-ci/crossplane-components/function-patch-and-transform@sha256:a174b3990f3721fe91c0f879b20dfbbd0a681b68cafe37a1cc09c69a246c9bf2
   runtimeConfigRef:
     name: function-runtime-config
 
@@ -54,7 +54,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-go-templating:v0.12.0
+  package: quay.io/konflux-ci/crossplane-components/function-go-templating@sha256:c4bbec60218eb8d7a2498ab80a1c07ba4ce7936a7291b2b94e9c6527ae51761f
   runtimeConfigRef:
     name: function-runtime-config
 
@@ -66,6 +66,6 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/function-auto-ready:v0.6.4
+  package: quay.io/konflux-ci/crossplane-components/function-auto-ready@sha256:35c76ab442914fdc607af4c3c2e6380c61fad728f49cd46f145e3be92b46c771
   runtimeConfigRef:
     name: function-runtime-config

--- a/config/provider-kubernetes.yaml
+++ b/config/provider-kubernetes.yaml
@@ -13,7 +13,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
 spec:
-  package: xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v1.2.1
+  package: quay.io/konflux-ci/crossplane-components/provider-kubernetes@sha256:ab40271ad7dc7fd90dc370d40b601d99bc73bbd32e299893519a17bedba14139
   runtimeConfigRef:
     name: provider-kubernetes-runtime-config
 

--- a/crossplane/kustomization.yaml
+++ b/crossplane/kustomization.yaml
@@ -2,9 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 helmCharts:
-  - name: crossplane
-    repo: https://charts.crossplane.io/stable
-    version: 2.2.1
+  - name: crossplane-helm
+    repo: oci://quay.io/konflux-ci/crossplane-components
+    version: 0.1.127+2bee55c
     releaseName: crossplane
     namespace: crossplane-system
     valuesFile: values.yaml

--- a/crossplane/values.yaml
+++ b/crossplane/values.yaml
@@ -6,6 +6,18 @@ rbacManager:
   replicas: 1
   leaderElection: false
 
+image:
+  repository: quay.io/konflux-ci/crossplane-components@sha256:7f050bdbef3f361861cf67077660c01fb2b3b4afbca780356d8e540dbb576da4
+  tag: ""
+  ignoreTag: true
+  pullPolicy: IfNotPresent
+
+provider:
+  packages: []
+
+function:
+  packages: []
+
 securityContextCrossplane:
   runAsNonRoot: true
   runAsUser: null


### PR DESCRIPTION
Replace the upstream crossplane Helm chart with the Konflux-built OCI chart, pin crossplane, all functions, and provider-kubernetes to specific quay.io digest images via dedicated DeploymentRuntimeConfigs, and increase deploy timeouts to accommodate OCI image pulls.

## Changes

- **`crossplane/kustomization.yaml`**: Switch from upstream Helm chart to Konflux OCI chart (`oci://quay.io/konflux-ci/crossplane-components`, version `0.1.127+2bee55c`)
- **`crossplane/values.yaml`**: Pin crossplane image to quay.io digest; set `pullPolicy: IfNotPresent`; override `provider.packages` and `function.packages` to empty to suppress invalid chart defaults; disable leader election
- **`config/functions.yaml`**: Pin all three functions (`function-patch-and-transform`, `function-go-templating`, `function-auto-ready`) to their latest quay.io digest images; point all `runtimeConfigRef` to the shared `function-runtime-config`
- **`config/provider-kubernetes.yaml`**: Pin provider-kubernetes `spec.package` and `DeploymentRuntimeConfig` image to latest quay.io digest
- **`scripts/deploy.sh`**: Increase `kubectl wait` timeouts to 120s to accommodate OCI image pulls

## Notes on `provider.packages: []` and `function.packages: []`

These empty overrides are a necessary guard against the Konflux Helm chart's default `values.yaml`, which includes unqualified package references for its bundled functions and providers. Without explicitly overriding them with empty lists, Crossplane will attempt to install those packages on startup and immediately fail with:

> `spec.package: Invalid value: "string": must be a fully qualified image name`

Since all function and provider installations are managed explicitly through `config/functions.yaml` and `config/provider-kubernetes.yaml`, the chart's defaults are not only unnecessary but actively harmful. These two lines are the guard that prevents them from taking effect.

Assisted-by: Cursor

Signed-off-by: Shaked Aviv <saviv@redhat.com>

Made with [Cursor](https://cursor.com)