### PR TITLE
Create an AGENTS.md guide and refactor existing docs and workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,6 +52,17 @@ jobs:
           echo "If this step fails, kube-linter found issues. Check the output of the scan step above."
           [[ "${{ steps.kube-linter-action-scan.outcome }}" == "success" ]]
 
+      - name: Verify AGENTS.md line count
+        shell: bash
+        run: |
+          max_lines=300
+          line_count=$(wc -l < AGENTS.md)
+          echo "AGENTS.md has $line_count lines (max: $max_lines)"
+          if [ "$line_count" -ge "$max_lines" ]; then
+            echo "AGENTS.md exceeds the $max_lines-line limit"
+            exit 1
+          fi
+
   deploy-test-cleanup:
     runs-on: ubuntu-latest
     steps:
@@ -63,22 +74,17 @@ jobs:
 
       - name: Deploy
         shell: bash
-        run: |
-          ./scripts/deploy.sh
-          kubectl apply -k examples/provider-kubernetes-in-cluster
+        run: ./scripts/deploy.sh
 
       - name: Test XNamespaces
         shell: bash
-        run: |
-          ./scripts/test-xnamespaces.sh
+        run: ./scripts/test-xnamespaces.sh
 
       - name: Test XTestPlatformCluster
         shell: bash
-        run: |
-          ./scripts/test-xtestplatformcluster.sh
+        run: ./scripts/test-xtestplatformcluster.sh
 
       - name: Cleanup
         shell: bash
-        run: |
-          kubectl delete -k examples/provider-kubernetes-in-cluster
-          ./scripts/cleanup.sh
+        run: ./scripts/cleanup.sh
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent Guidelines for crossplane-control-plane
+
+## Project Overview
+
+Configuration for deploying Crossplane core controllers, functions, providers, XRDs,
+and compositions for use within Konflux.
+
+## Project Structure
+- `crossplane/`             - Helm chart for Crossplane core (kustomize + helm inflation)
+- `config/`                 - Providers, functions, XRDs, and compositions (deployed via kustomize)
+- `config/<xrd>/templates/` - Go templates mounted into the function runtime as `ConfigMaps`
+- `examples/`               - Example claims, prerequisite ProviderConfigs and RBAC configuration
+- `scripts/`                - Deploy, test, and cleanup scripts
+
+## Development
+
+- Only utilize Crossplane helm charts, providers and functions packaged by the
+  https://github.com/konflux-ci/crossplane-components repository.
+- Only use OCI images referenced by digest, never by tag.
+- Always store sensitive composition resources in `Secrets`.
+
+### How to Add a New XRD/Composition
+- Create `xrd.yaml`, `composition.yaml`, `kustomization.yaml`, and `templates/` within `config/<name>/`.
+- Add the templates volume mount in `config/functions.yaml` (`DeploymentRuntimeConfig`)
+- Add the new directory to `config/kustomization.yaml`
+- Create an example claim in `examples/<name>/`
+- Create a test script in `scripts/`
+
+## Verifying Changes
+
+All tests require a kubernetes cluster. There are no unit tests.
+
+```
+kind create cluster                    # create a kind cluster
+./scripts/deploy.sh                    # deploy everything
+./scripts/test-xnamespaces.sh          # run XNamespace tests 
+./scripts/test-xtestplatformcluster.sh # run XTestPlatform tests
+./scripts/cleanup.sh                   # cleanup everything
+```
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -1,35 +1,22 @@
 # crossplane-control-plane
-This repository contains all configuration needed to setup crossplane for use
-with Konflux.
+This repository contains all configuration needed to setup crossplane for use with Konflux.
 
-# Installation
+# Getting Started
 
-The quickest way to install everything is to run the `deploy.sh` script.
+The quickest way to get started is to run the `deploy.sh` script.
 
 ```bash
 ./scripts/deploy.sh
 ```
 
-This will install crossplane from a helm chart and then deploy our control plane
-configuration.
+This deploys crossplane from a helm chart, all necessary providers and functions, and our XRD
+configuration to a kubernetes/OpenShift cluster.
 
-## Crossplane Helm Chart
+It also deploys some example ProviderConfigs and RBAC configuration necessary to test the compositions.
+Refer to the [provider-kubernetes-in-cluster](./examples/provider-kubernetes-in-cluster/) example to
+learn about these prerequisites.
 
-Here we have used Kustomization's Helm Chart Inflation Generator to install crossplane.
-
-```bash
-kustomize build --enable-helm crossplane/ | kubectl apply -f -
-```
-
-This installs crossplane in the `crossplane-system` namespace.
-
-## Control Plane Configuration
-
-```bash
-kubectl apply -k config/
-```
-
-# Cleanup
+All resources can be removed using the cleanup script.
 
 ```bash
 ./scripts/cleanup.sh
@@ -41,32 +28,19 @@ kubectl apply -k config/
 
 Provides a kubernetes namespace for deploying and testing software.
 
-### Prerequisites
-
-- A `ProviderConfig` named `eaas-kubernetes-provider-config` referencing a secret with the keys:
-  - `apiserver`: The URL of the kubernetes API server
-  - `kubeconfig`: A valid kubeconfig for authenticating to the cluster
-- The account associated with the kubeconfig must be granted full control of:
-    - `LimitRanges`
-    - `Namespaces`
-    - `NetworkPolicies`
-    - `ResourceQuotas`
-    - `RoleBindings`
-    - `Secrets`
-    - `ServiceAccounts`
-- The account must also be granted the `edit` ClusterRole.
-
-All of this is configured in an example which sets up the kubernetes provider
-to interact with the local cluster.
-
-```bash
-kubectl apply -k examples/provider-kubernetes-in-cluster
-```
-
-### Usage
-
-See the [examples](./examples/xnamespace/) or execute this script:
+See [here](./examples/xnamespace/) for an example claim or run a test with it using:
 
 ```bash
 ./scripts/test-xnamespaces.sh
 ```
+
+## xtestplatformcluster.ci.openshift.org
+
+Provisions an ephemeral OpenShift cluster via OpenShift-CI infrastructure.
+
+See [here](./examples/xtestplatformcluster/) for an example claim or run a test with it using:
+
+```bash
+./scripts/test-xtestplatformcluster.sh
+```
+

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -3,8 +3,11 @@ set -eu -o pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
 
+kubectl delete --ignore-not-found -k $ROOT/examples/provider-kubernetes-in-cluster
+
 kubectl delete --ignore-not-found -k $ROOT/config/
 
 kustomize build --enable-helm $ROOT/crossplane/ | kubectl delete --ignore-not-found -f -
 
 kubectl get crds -o name | grep "\.crossplane\.io$" | xargs --no-run-if-empty kubectl delete
+

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -8,3 +8,6 @@ kubectl wait --for=condition=Available deployment -n crossplane-system --all --t
 
 kubectl apply -k $ROOT/config/
 kubectl wait --for=condition=Healthy functions,providers --all --timeout=120s
+
+kubectl apply -k $ROOT/examples/provider-kubernetes-in-cluster
+


### PR DESCRIPTION
Assisted-by: Claude Opus 4.6

# AGENTS.md Validation

Evidence that `AGENTS.md` improves AI agent performance on repository tasks.

## Experiment

**Task:** "List all files to create or modify to add a new XRD called `xfoo`. Include any constraints on image references or sensitive data handling."

Two AI agents (Claude, Explore mode) were given the same task in the same repo:

- **Agent A (no guidance):** Instructed to skip `AGENTS.md`/`CLAUDE.md` and explore the codebase independently.
- **Agent B (with guidance):** Instructed to read `AGENTS.md` first, then explore to validate and supplement.

## Results

| Criterion | Agent A (no guidance) | Agent B (with AGENTS.md) |
|---|---|---|
| Core files identified (xrd, composition, kustomization, templates) | Yes | Yes |
| Update config/kustomization.yaml | Yes | Yes |
| Update config/functions.yaml volume mount | Yes | Yes |
| Example claim and test script | Yes | Yes |
| Image digest-only constraint | Observed from files | Stated as a rule |
| Secrets-in-Secrets constraint | Observed from files | Stated as a rule |
| **Upstream source constraint** (must use konflux-ci/crossplane-components) | **Missed** | **Identified** |
| Unnecessary steps included | Yes (deploy script, README) | No |
| CI workflow update accuracy | Listed as required | Correctly marked optional |

### Critical finding

Agent A never identified that providers and functions **must** come from [konflux-ci/crossplane-components](https://github.com/konflux-ci/crossplane-components). It noticed the `quay.io/konflux-ci/crossplane-components/` registry pattern but framed it as an observation, not a constraint. An agent acting on Agent A's output could introduce a provider from an arbitrary upstream source.

Agent B cited this constraint directly from `AGENTS.md` and applied it as a rule.

### Secondary findings

- Agent A produced 13 checklist items; Agent B produced 10 (no unnecessary items).
- Agent A framed constraints as observations ("images use digest format"); Agent B  framed them as rules ("must use digest, never tag"). Observations are weaker  guidance — an agent may override an observed pattern if it seems convenient.
- Agent A incorrectly listed the CI workflow update as required; Agent B correctly  marked it as optional.

## Reproduction

Run the same experiment using any AI coding agent (Claude Code, Copilot, Codex, etc.):

```bash
# Agent A: run in the repo root without AGENTS.md
# Prompt: "Do NOT read AGENTS.md or CLAUDE.md. List all files to create or
# modify to add a new XRD called xfoo, including constraints on image
# references or sensitive data handling."

# Agent B: run in the repo root with AGENTS.md
# Prompt: "Read AGENTS.md first. List all files to create or modify to add
# a new XRD called xfoo, including constraints on image references or
# sensitive data handling."
```

Compare the two outputs against the checklist in [AGENTS.md](../AGENTS.md) under
"How to Add a New XRD/Composition" and the Development constraints.