### PR TITLE
TestPlatformCluster: Update readiness criteria on the EphemeralCluster Object

### DIFF
--- a/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
+++ b/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
@@ -19,6 +19,11 @@ spec:
 {{- if hasKey .observed.composite.resource.spec "tearDownCluster" }}
         tearDownCluster: {{ .observed.composite.resource.spec.tearDownCluster }}
 {{- end }}
+  readiness:
+    policy: DeriveFromCelQuery
+    celQuery: |
+      has(object.status) && has(object.status.conditions) &&
+      object.status.conditions.exists(c, c.type == 'ClusterReady' && c.status == 'True')
   watch: true
   providerConfigRef:
     name: testplatform-kubernetes-provider-config


### PR DESCRIPTION
Readiness criteria is `SuccessfulCreate` that doesn't account for the ephemeral cluster to be actually up and running.
It has also been observed that, with the default policy, the `provider-kubernetes` controller didn't set `Ready: True` even after the `EphemeralCluster` has been successfully created:
```yaml
apiVersion: kubernetes.crossplane.io/v1alpha2
kind: Object
metadata:
  annotations:
    crossplane.io/composition-resource-name: ec
    crossplane.io/external-create-pending: "2026-06-01T14:31:31Z"
    crossplane.io/external-create-succeeded: "2026-06-01T14:31:31Z"
    crossplane.io/external-name: managed-insights-on-prem-smoke-test-dbk4p-provision-cluster-6796c
  creationTimestamp: "2026-06-01T14:31:31Z"
  finalizers:
  - finalizer.managedresource.crossplane.io
  generation: 2
  labels:
    crossplane.io/claim-name: insights-on-prem-smoke-test-dbk4p-provision-cluster
    crossplane.io/claim-namespace: obsint-processing-tenant
    crossplane.io/composite: insights-on-prem-smoke-test-dbk4p-provision-cluster-6796c
  name: managed-insights-on-prem-smoke-test-dbk4p-provision-cluster-6796c
  ownerReferences:
  - apiVersion: ci.openshift.org/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: XTestPlatformCluster
    name: insights-on-prem-smoke-test-dbk4p-provision-cluster-6796c
    uid: eb69accf-7547-4a26-8407-0f872d3d1926
  resourceVersion: "9124652513"
  uid: 6e11feeb-5202-4182-a4dd-07046190c65b
spec:
  deletionPolicy: Delete
  forProvider:
    manifest:
      apiVersion: ci.openshift.io/v1
      kind: EphemeralCluster
      metadata:
        name: insights-on-prem-smoke-test-dbk4p-provision-cluster-6796c
        namespace: ephemeral-cluster
      spec:
        ciOperator:
          baseImages: {}
          buildRoot:
            image_stream_tag:
              name: release
              namespace: openshift
              tag: rhel-9-release-golang-1.24-openshift-4.20
          externalImages: {}
          releases: {}
          test:
            clusterClaim:
              architecture: amd64
              cloud: aws
              owner: obs
              product: ocp
              timeout: 3h0m0s
              version: "4.21"
            env: {}
            workflow: generic-claim
  managementPolicies:
  - '*'
  providerConfigRef:
    name: testplatform-kubernetes-provider-config
  readiness:
    policy: SuccessfulCreate
  watch: true
status:
  atProvider:
    manifest:
      apiVersion: ci.openshift.io/v1
      kind: EphemeralCluster
      metadata:
        creationTimestamp: "2026-06-01T14:31:31Z"
        finalizers:
        - ephemeralcluster.ci.openshift.io/dependent-prowjob
        generation: 1348
        managedFields:
        - apiVersion: ci.openshift.io/v1
          fieldsType: FieldsV1
          fieldsV1:
            f:spec:
              f:ciOperator:
                f:baseImages: {}
                f:buildRoot:
                  f:image_stream_tag:
                    f:name: {}
                    f:namespace: {}
                    f:tag: {}
                f:externalImages: {}
                f:releases: {}
                f:test:
                  f:clusterClaim:
                    f:architecture: {}
                    f:cloud: {}
                    f:owner: {}
                    f:product: {}
                    f:timeout: {}
                    f:version: {}
                  f:env: {}
                  f:workflow: {}
          manager: provider-kubernetes/managed-insights-on-prem-smoke-test-dbk4p-provision-cluster-6796c
          operation: Apply
          time: "2026-06-01T15:56:03Z"
        - apiVersion: ci.openshift.io/v1
          fieldsType: FieldsV1
          fieldsV1:
            f:metadata:
              f:finalizers:
                .: {}
                v:"ephemeralcluster.ci.openshift.io/dependent-prowjob": {}
            f:spec:
              f:ciOperator:
                f:baseImages:
                  f:cli:
                    .: {}
                    f:name: {}
                    f:namespace: {}
                    f:tag: {}
            f:status:
              .: {}
              f:conditions: {}
              f:phase: {}
              f:prowJobId: {}
              f:prowJobURL: {}
              f:secretRef: {}
          manager: dptp-controller-manager
          operation: Update
          time: "2026-06-01T15:56:00Z"
        name: insights-on-prem-smoke-test-dbk4p-provision-cluster-6796c
        namespace: ephemeral-cluster
        resourceVersion: "7599175741"
        uid: b97e1210-5375-47f6-b5f6-98acb9e92d86
      spec:
        ciOperator:
          baseImages:
            cli:
              name: "4.21"
              namespace: ocp
              tag: cli
          buildRoot:
            image_stream_tag:
              name: release
              namespace: openshift
              tag: rhel-9-release-golang-1.24-openshift-4.20
          externalImages: {}
          releases: {}
          test:
            clusterClaim:
              architecture: amd64
              cloud: aws
              owner: obs
              product: ocp
              timeout: 3h0m0s
              version: "4.21"
            env: {}
            workflow: generic-claim
      status:
        conditions:
        - lastTransitionTime: "2026-06-01T15:56:00Z"
          reason: ProwJob has been properly created
          status: "False"
          type: ProwJobCreating
        - lastTransitionTime: "2026-06-01T15:56:00Z"
          status: "True"
          type: ClusterReady
        phase: Ready
        prowJobId: 9f115a6f-27a7-49aa-a264-ddfdfbac0abb
        prowJobURL: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/ephemeralcluster-ci-org-repo-branch-cluster-provisioning/2061463976138510336
        secretRef: insights-on-prem-smoke-test-dbk4p-provision-cluster-6796c-credentials
  conditions:
  - lastTransitionTime: "2026-06-01T14:31:31Z"
    observedGeneration: 2
    reason: Creating
    status: "False"
    type: Ready
  - lastTransitionTime: "2026-06-01T14:31:31Z"
    observedGeneration: 2
    reason: ReconcileSuccess
    status: "True"
    type: Synced
```

By looking at this condition:
```yaml
  conditions:
  - lastTransitionTime: "2026-06-01T14:31:31Z"
    observedGeneration: 2
    reason: Creating
    status: "False"
    type: Ready
```
it seems that the object is not ready since the `EphemeralCluster` is still in `Creating`, which was not the case.