### PR TITLE
Change default reviewers to @konflux-ci/Vanguard

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,7 @@
-* @konflux-ci/eaas-maintainers
+# CODEOWNERS
+# This file defines the default reviewers for pull requests in this repository.
+# Members of the Vanguard team will be automatically requested as reviewers.
+
+# Global rule: All files require review from the Vanguard team
+* @konflux-ci/Vanguard
+


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Set @konflux-ci/Vanguard as default CODEOWNERS reviewers
<code>⚙️ Configuration changes</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Replace default CODEOWNERS team to route reviews to @konflux-ci/Vanguard.
• Add explanatory comments documenting reviewer intent and global ownership rule.
</pre>
</details>

<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Keep previous default team (@konflux-ci/eaas-maintainers)</b></summary>

- ➕ No change in review routing; avoids potential gaps during team transition
- ➖ Does not reflect current ownership if Vanguard is now responsible
- ➖ May slow reviews if maintainers are no longer the active on-call group

</details>

<details>
<summary><b>2. Use multiple CODEOWNERS groups for redundancy</b></summary>

- ➕ Provides coverage if one team is unavailable
- ➕ Can ease transition by including both old and new owner teams temporarily
- ➖ Increases reviewer noise and may over-request reviewers
- ➖ Blurs accountability for approvals

</details>

**Recommendation:** The PR’s approach (global ownership by @konflux-ci/Vanguard) is appropriate if Vanguard is the accountable team for the repo. If this is a transition, consider temporarily including both teams to avoid missed reviews, then remove the old team once the handoff is complete.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>CODEOWNERS</strong> <code>Route default PR reviews to @konflux-ci/Vanguard</code> <code>+7/-1</code></summary>

<br/>

>Route default PR reviews to @konflux-ci/Vanguard
>
><pre>
>• Replaces the previous wildcard CODEOWNERS entry with @konflux-ci/Vanguard and adds comments explaining that Vanguard is the default reviewer group for all files.
></pre>
>
><a href='https://github.com/konflux-ci/crossplane-control-plane/pull/116/files#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085b'>CODEOWNERS</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>