### PR TITLE
fix: disable correct renovate manager for crossplane/values.yaml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -30,7 +30,7 @@
         "crossplane/values.yaml"
       ],
       "matchManagers": [
-        "docker"
+        "helm-values"
       ],
       "enabled": false
     }


### PR DESCRIPTION
The helm-values built-in manager was auto-detecting the image reference in crossplane/values.yaml and producing PRs with mangled double-digests (e.g. repo@sha256:NEW@sha256:OLD). The packageRule intended to suppress this duplicate detection was targeting the "docker" manager, but the actual built-in manager matching the file is "helm-values".

Ref: https://github.com/konflux-ci/crossplane-control-plane/pull/133

Assisted-by: Claude claude-opus-4-6