### PR TITLE
Add konflux-tenant and konflux-cluster annotations to EphemeralCluster

### DIFF
--- a/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
+++ b/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
@@ -1,5 +1,13 @@
-{{ $annotations := .observed.composite.resource.metadata.annotations -}}
+apiVersion: meta.gotemplating.fn.crossplane.io/v1alpha1
+kind: ExtraResources
+requirements:
+  envcfg:
+    apiVersion: apiextensions.crossplane.io/v1beta1
+    kind: EnvironmentConfig
+    matchName: envcfg
+
 ---
+{{- if .extraResources.envcfg.items }}
 apiVersion: kubernetes.crossplane.io/v1alpha2
 kind: Object
 metadata:
@@ -14,6 +22,9 @@ spec:
       metadata:
         name: {{ .observed.composite.resource.metadata.name }}
         namespace: ephemeral-cluster
+        annotations:
+          ephemeralcluster.ci.openshift.io/konflux-tenant: {{ .observed.composite.resource.spec.claimRef.namespace }}
+          ephemeralcluster.ci.openshift.io/konflux-cluster: {{ (first .extraResources.envcfg.items).resource.data.clusterName }}
       spec:
         ciOperator: {{ .observed.composite.resource.spec.ciOperator|toPrettyJson }}
 {{- if hasKey .observed.composite.resource.spec "tearDownCluster" }}
@@ -27,3 +38,4 @@ spec:
   watch: true
   providerConfigRef:
     name: testplatform-kubernetes-provider-config
+{{- end }}

--- a/examples/xtestplatformcluster/environment-config.yaml
+++ b/examples/xtestplatformcluster/environment-config.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: apiextensions.crossplane.io/v1beta1
+kind: EnvironmentConfig
+metadata:
+  name: envcfg
+data:
+  clusterName: test-cluster

--- a/scripts/test-xtestplatformcluster.sh
+++ b/scripts/test-xtestplatformcluster.sh
@@ -15,11 +15,11 @@ ephemeralcluster_crd='https://raw.githubusercontent.com/openshift/ci-tools/refs/
 curl -sSL "$ephemeralcluster_crd" | kubectl apply -f -
 kubectl wait crd/"$ec_group" --for=condition=Established=true --for=condition=NamesAccepted=true
 
-kubectl apply -f $ROOT/examples/xtestplatformcluster/namespaces.yaml
-kubectl apply -f $ROOT/examples/xtestplatformcluster/environment-config.yaml
+kubectl apply -f "$ROOT"/examples/xtestplatformcluster/namespaces.yaml
+kubectl apply -f "$ROOT"/examples/xtestplatformcluster/environment-config.yaml
 
 # Create a claim
-kubectl apply -f $ROOT/examples/xtestplatformcluster/claim.yaml
+kubectl apply -f "$ROOT"/examples/xtestplatformcluster/claim.yaml
 kubectl wait $xr_group -l "$claim_label" --for=condition=Synced=true --timeout=3m
 
 # Simulate what the EphemeralCluster controller does: create a credentials Secret and set secretRef in the EphemeralCluster status.
@@ -111,5 +111,5 @@ if [ "$want_cluster" != "$got_cluster" ]; then
 fi
 
 # Clean everything up
-kubectl delete -f $ROOT/examples/xtestplatformcluster
+kubectl delete -f "$ROOT"/examples/xtestplatformcluster
 kubectl wait objects.kubernetes.crossplane.io --for=delete --all --timeout=3m

--- a/scripts/test-xtestplatformcluster.sh
+++ b/scripts/test-xtestplatformcluster.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"/..
 source "$ROOT/scripts/debug-dump.sh"
 claim_group="testplatformclusters.ci.openshift.org"
 xr_group="xtestplatformclusters.ci.openshift.org"
+ec_group="ephemeralclusters.ci.openshift.io"
 claim_name="tp-aws-cluster"
 claim_label="crossplane.io/claim-name=$claim_name"
 register_debug_dump "$claim_group" "$claim_name"
@@ -12,9 +13,10 @@ register_debug_dump "$claim_group" "$claim_name"
 # Install the EphemeralCluster CRD
 ephemeralcluster_crd='https://raw.githubusercontent.com/openshift/ci-tools/refs/heads/main/pkg/api/ephemeralcluster/v1/ci.openshift.io_ephemeralclusters.yaml'
 curl -sSL "$ephemeralcluster_crd" | kubectl apply -f -
-kubectl wait crd/ephemeralclusters.ci.openshift.io --for=condition=Established=true --for=condition=NamesAccepted=true
+kubectl wait crd/"$ec_group" --for=condition=Established=true --for=condition=NamesAccepted=true
 
 kubectl apply -f $ROOT/examples/xtestplatformcluster/namespaces.yaml
+kubectl apply -f $ROOT/examples/xtestplatformcluster/environment-config.yaml
 
 # Create a claim
 kubectl apply -f $ROOT/examples/xtestplatformcluster/claim.yaml
@@ -44,7 +46,7 @@ ec_patch='[{
 }]'
 
 ephemeralcluster="$(kubectl get $xr_group -l "$claim_label" -o jsonpath='{.items[0].metadata.name}')"
-kubectl -n ephemeral-cluster patch ephemeralclusters.ci.openshift.io/"$ephemeralcluster" --type=json -p="$ec_patch"
+kubectl -n ephemeral-cluster patch "$ec_group"/"$ephemeralcluster" --type=json -p="$ec_patch"
 
 # Wait for the EphemeralCluster's conditions to be propagated to both the Composite Resource and Claim
 kubectl wait $xr_group -l "$claim_label" --for=condition=ClusterReady=true --for=condition=Ready=true --timeout=3m
@@ -87,6 +89,24 @@ want_pjurl='https://prowjob.fake'
 
 if [ "$want_pjurl" != "$got_pjurl" ]; then
     echo "want prowJobURL '$want_pjurl' but got '$got_pjurl'"
+    exit 1
+fi
+
+# Make sure the EphemeralCluster has the konflux-tenant annotation set to the claim namespace
+got_tenant="$(kubectl -n ephemeral-cluster get "$ec_group"/"$ephemeralcluster" -o jsonpath='{.metadata.annotations.ephemeralcluster\.ci\.openshift\.io/konflux-tenant}')"
+want_tenant='default'
+
+if [ "$want_tenant" != "$got_tenant" ]; then
+    echo "want konflux-tenant annotation '$want_tenant' but got '$got_tenant'"
+    exit 1
+fi
+
+# Make sure the EphemeralCluster has the konflux-cluster annotation set to the EnvironmentConfig cluster name
+got_cluster="$(kubectl -n ephemeral-cluster get "$ec_group"/"$ephemeralcluster" -o jsonpath='{.metadata.annotations.ephemeralcluster\.ci\.openshift\.io/konflux-cluster}')"
+want_cluster='test-cluster'
+
+if [ "$want_cluster" != "$got_cluster" ]; then
+    echo "want konflux-cluster annotation '$want_cluster' but got '$got_cluster'"
     exit 1
 fi
 


### PR DESCRIPTION
The EphemeralCluster controller needs to know which Konflux tenant namespace originated a TestPlatformCluster claim and which cluster it is running on. The claim namespace is propagated via claimRef and the cluster name is read from the "envcfg" EnvironmentConfig using an ExtraResources lookup in the Go template.

Assisted-by: Claude claude-opus-4-6