### PR TITLE
KFLUXVNGD-1121 Set nameOverride to preserve crossplane deployment name

### DIFF
--- a/crossplane/values.yaml
+++ b/crossplane/values.yaml
@@ -1,4 +1,5 @@
 ---
+nameOverride: crossplane
 replicas: 1
 leaderElection: false
 


### PR DESCRIPTION
The chart is published as crossplane-helm, which causes the Helm template to name the Deployment crossplane-helm instead of crossplane. This breaks downstream strategic merge patches that target the Deployment by name. Setting nameOverride restores the original name.

Assisted-by: Claude claude-opus-4-6