### PR TITLE
Add Renovate custom manager for crossplane-helm chart

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,19 @@
       "autoReplaceStringTemplate": "repository: {{{depName}}}@{{{newDigest}}}",
       "currentValueTemplate": "latest",
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^crossplane/kustomization\\.yaml$/"
+      ],
+      "matchStrings": [
+        "version:\\s+(?<currentValue>\\S+)"
+      ],
+      "depNameTemplate": "quay.io/konflux-ci/crossplane-components/crossplane-helm",
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)([_+](?<build>.+))?$",
+      "autoReplaceStringTemplate": "version: {{{replace '_' '+' newValue}}}"
     }
   ],
   "packageRules": [
@@ -31,6 +44,15 @@
       ],
       "matchManagers": [
         "helm-values"
+      ],
+      "enabled": false
+    },
+    {
+      "matchFileNames": [
+        "crossplane/kustomization.yaml"
+      ],
+      "matchManagers": [
+        "kustomize"
       ],
       "enabled": false
     }


### PR DESCRIPTION
The crossplane-helm OCI chart in crossplane/kustomization.yaml was not covered by any Renovate manager. A custom regex manager is added to track version updates from the OCI registry, with regex versioning to handle the underscore/plus semver build metadata difference between OCI tags and Helm's semver requirement. The built-in kustomize manager is disabled for that file to avoid a redundant invalid-value skip.

Assisted-by: Claude claude-opus-4-6