### PR TITLE
Fix Renovate crossplane-helm update failure

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,7 @@
         "version:\\s+(?<currentValue>\\S+)"
       ],
       "depNameTemplate": "quay.io/konflux-ci/crossplane-components/crossplane-helm",
+      "currentValueTemplate": "{{{replace '\\+' '_' currentValue}}}",
       "datasourceTemplate": "docker",
       "versioningTemplate": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)([_+](?<build>.+))?$",
       "autoReplaceStringTemplate": "version: {{{replace '_' '+' newValue}}}"


### PR DESCRIPTION
Renovate's post-update verification re-extracts the file and compares the result against newValue from the registry. The registry tags use underscores (0.1.231_eef4b49) while the file needs semver plus signs (0.1.231+eef4b49) for Helm compatibility. Without normalizing, the verification always fails with "Value is not updated".

Adding currentValueTemplate to normalize + to _ during extraction ensures the re-extracted value matches the registry's newValue, while autoReplaceStringTemplate still writes + to the file.

Assisted-by: Claude claude-opus-4-6