### PR TITLE
TestPlatformCluster: Propagate PipelineRun and TaskRun names into the EphemeralCluster annotations

### DIFF
--- a/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
+++ b/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
@@ -26,14 +26,14 @@ spec:
         annotations:
           ephemeralcluster.ci.openshift.io/konflux-tenant: {{ .observed.composite.resource.spec.claimRef.namespace }}
           ephemeralcluster.ci.openshift.io/konflux-cluster: {{ (first .extraResources.envcfg.items).resource.data.clusterName }}
-{{ if ne $resource_annotations nil }}
-  {{ $pipeline_run_name := index $resource_annotations "ephemeralcluster.ci.openshift.io/pipeline-run-name" }}
-  {{ $task_run_name := index $resource_annotations "ephemeralcluster.ci.openshift.io/task-run-name" }}
+{{- if ne $resource_annotations nil }}
+  {{- $pipeline_run_name := index $resource_annotations "ephemeralcluster.ci.openshift.io/pipeline-run-name" }}
+  {{- $task_run_name := index $resource_annotations "ephemeralcluster.ci.openshift.io/task-run-name" }}
           ephemeralcluster.ci.openshift.io/task-run-name: {{ $task_run_name }}
   {{- if ne $pipeline_run_name nil }}
           ephemeralcluster.ci.openshift.io/pipeline-run-name: {{ $pipeline_run_name }}
   {{- end }}
-{{ end }}
+{{- end }}
       spec:
         ciOperator: {{ .observed.composite.resource.spec.ciOperator|toPrettyJson }}
 {{- if hasKey .observed.composite.resource.spec "tearDownCluster" }}

--- a/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
+++ b/config/xtestplatformcluster/templates/create-ephemeral-cluster.yaml
@@ -7,6 +7,7 @@ requirements:
     matchName: envcfg
 
 ---
+{{- $resource_annotations := .observed.composite.resource.metadata.annotations }}
 {{- if .extraResources.envcfg.items }}
 apiVersion: kubernetes.crossplane.io/v1alpha2
 kind: Object
@@ -25,6 +26,14 @@ spec:
         annotations:
           ephemeralcluster.ci.openshift.io/konflux-tenant: {{ .observed.composite.resource.spec.claimRef.namespace }}
           ephemeralcluster.ci.openshift.io/konflux-cluster: {{ (first .extraResources.envcfg.items).resource.data.clusterName }}
+{{ if ne $resource_annotations nil }}
+  {{ $pipeline_run_name := index $resource_annotations "ephemeralcluster.ci.openshift.io/pipeline-run-name" }}
+  {{ $task_run_name := index $resource_annotations "ephemeralcluster.ci.openshift.io/task-run-name" }}
+          ephemeralcluster.ci.openshift.io/task-run-name: {{ $task_run_name }}
+  {{- if ne $pipeline_run_name nil }}
+          ephemeralcluster.ci.openshift.io/pipeline-run-name: {{ $pipeline_run_name }}
+  {{- end }}
+{{ end }}
       spec:
         ciOperator: {{ .observed.composite.resource.spec.ciOperator|toPrettyJson }}
 {{- if hasKey .observed.composite.resource.spec "tearDownCluster" }}

--- a/examples/xtestplatformcluster/claim.yaml
+++ b/examples/xtestplatformcluster/claim.yaml
@@ -2,6 +2,9 @@
 apiVersion: ci.openshift.org/v1alpha1
 kind: TestPlatformCluster
 metadata:
+  annotations:
+    ephemeralcluster.ci.openshift.io/pipeline-run-name: foo
+    ephemeralcluster.ci.openshift.io/task-run-name: bar
   name: tp-aws-cluster
 spec:
   ciOperator:

--- a/scripts/test-xtestplatformcluster.sh
+++ b/scripts/test-xtestplatformcluster.sh
@@ -138,6 +138,20 @@ if [ "$want_cluster" != "$got_cluster" ]; then
     exit 1
 fi
 
+got_pipelinerun_name="$(kubectl -n ephemeral-cluster get "$ec_group/$ephemeralcluster" -o jsonpath='{.metadata.annotations.ephemeralcluster\.ci\.openshift\.io/pipeline-run-name}')"
+want_pipelinerun_name='foo'
+if [ "$want_pipelinerun_name" != "$got_pipelinerun_name" ]; then
+    echo "want PipelineRun name '$want_pipelinerun_name' but got '$got_pipelinerun_name'"
+    exit 1
+fi
+
+got_taskrun_name="$(kubectl -n ephemeral-cluster get "$ec_group/$ephemeralcluster" -o jsonpath='{.metadata.annotations.ephemeralcluster\.ci\.openshift\.io/task-run-name}')"
+want_taskrun_name='bar'
+if [ "$want_taskrun_name" != "$got_taskrun_name" ]; then
+    echo "want TaskRun name '$want_taskrun_name' but got '$got_taskrun_name'"
+    exit 1
+fi
+
 # Clean everything up
 kubectl delete -f "$ROOT"/examples/xtestplatformcluster
 kubectl wait objects.kubernetes.crossplane.io --for=delete --all --timeout="$wait_timeout"


### PR DESCRIPTION
`PipelineRun` and `TaskRun` names have been made available with https://github.com/openshift/konflux-tasks/pull/33. This PR propagates them into the `EphemeralCluster`'s annotations.