### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Run kustomize build
         id: kube-linter-action-scan
@@ -35,7 +35,7 @@ jobs:
         run: mkdir -p ../results
 
       - name: Scan with kube-linter
-        uses: stackrox/kube-linter-action@v1.0.7
+        uses: stackrox/kube-linter-action@87802a2f4e01abebb3ee3c67a3002fea71f6eae5  # v1.0.7
         with:
           directory: manifests
           format: sarif
@@ -43,7 +43,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload SARIF report files to GitHub
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3  # v4
 
       # Ensure the workflow eventually fails if files did not pass kube-linter checks.
       - name: Verify kube-linter-action succeeded
@@ -67,10 +67,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc  # v1
 
       - name: Deploy
         shell: bash

--- a/.github/workflows/differential-shellcheck.yaml
+++ b/.github/workflows/differential-shellcheck.yaml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Repository checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           # Differential ShellCheck requires full git history
           fetch-depth: 0

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -16,7 +16,7 @@ jobs:
       yaml: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
         with:
           fetch-depth: 0
       - name: Check for changes
@@ -36,7 +36,7 @@ jobs:
     if: needs.check-changes.outputs.yaml == 'true'
     steps:
       - name: Clone the code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7
 
       - name: Run yamllint
         uses: frenck/action-yamllint@34b4bbcaeabedcfefad6adea8c5bbc42af0e2d47  # v1


### PR DESCRIPTION
## Summary
- Pin GitHub Actions in workflows to full 40-character commit SHAs with inline version comments so Renovate can keep updating them.
- Leave org reusable `fullsend` workflow refs on `@main` unchanged where present.

## Test plan
- [ ] Workflows that use the pinned actions still pass CI
- [ ] YAML lint (if present) is clean for comment spacing before `#`

Made with [Cursor](https://cursor.com)